### PR TITLE
feat: movable and hideable columns

### DIFF
--- a/prostars/static/js/stats-app.js
+++ b/prostars/static/js/stats-app.js
@@ -210,7 +210,7 @@ function initTabulator(tabConfig, data, onRowSelected) {
     paginationSizeSelector: [10, 25, 50, 100],
     paginationMode: "local",
     paginationCounter: "rows",
-    movableColumns: false,
+    movableColumns: true,
     responsiveLayout: false,
     selectableRows: 1,
   };
@@ -245,13 +245,19 @@ const prostarsApp = createApp({
     const isLoading      = ref({});
     const loadError      = ref({});
     const filterOpen     = ref(false);
+    const colPanelOpen   = ref(false);
     const filters        = ref({});
+    const columnVisibility = ref({});
     const selectedPlayer = ref(null);
 
     tabs.forEach(tab => {
       filters.value[tab.id] = {};
       tab.filterItems.forEach(item => {
         filters.value[tab.id][item] = [];
+      });
+      columnVisibility.value[tab.id] = {};
+      tab.headers.slice(1).forEach(h => {
+        columnVisibility.value[tab.id][h] = true;
       });
     });
 
@@ -446,6 +452,7 @@ const prostarsApp = createApp({
       selectedPlayer.value = null;
       activeTabId.value = tabId;
       filterOpen.value = false;
+      colPanelOpen.value = false;
       loadTab(tabId);
     }
 
@@ -469,6 +476,13 @@ const prostarsApp = createApp({
       computeHeatStats(tab.tableId, filtered, tab.heatmapColumns || []);
       applyTableData(tab.tableId, filtered);
       filterOpen.value = false;
+      // Restore all hidden columns
+      const table = tabulatorInstances[tab.tableId];
+      const fieldMap = tab.fieldMap || {};
+      tab.headers.slice(1).forEach(h => {
+        columnVisibility.value[tab.id][h] = true;
+        if (table) table.showColumn(fieldMap[h] || h);
+      });
     }
 
     function selectAll(tabId, groupKey) {
@@ -489,6 +503,19 @@ const prostarsApp = createApp({
       const filtered = filteredData.value;
       computeHeatStats(tab.tableId, filtered, tab.heatmapColumns || []);
       applyTableData(tab.tableId, filtered);
+    }
+
+    function toggleColumn(tabId, header) {
+      const tab = tabs.find(t => t.id === tabId);
+      if (!tab) return;
+      const visible = !columnVisibility.value[tabId][header];
+      columnVisibility.value[tabId][header] = visible;
+      const table = tabulatorInstances[tab.tableId];
+      if (!table) return;
+      const fieldMap = tab.fieldMap || {};
+      const field = fieldMap[header] || header;
+      if (visible) table.showColumn(field);
+      else table.hideColumn(field);
     }
 
     function closePanel() {
@@ -538,7 +565,10 @@ const prostarsApp = createApp({
       isLoading,
       loadError,
       filterOpen,
+      colPanelOpen,
       filters,
+      columnVisibility,
+      toggleColumn,
       activeTab,
       activeData,
       filteredData,

--- a/prostars/static/js/stats-app.js
+++ b/prostars/static/js/stats-app.js
@@ -476,13 +476,10 @@ const prostarsApp = createApp({
       computeHeatStats(tab.tableId, filtered, tab.heatmapColumns || []);
       applyTableData(tab.tableId, filtered);
       filterOpen.value = false;
-      // Restore all hidden columns
+      // Reset column order and visibility
       const table = tabulatorInstances[tab.tableId];
-      const fieldMap = tab.fieldMap || {};
-      tab.headers.slice(1).forEach(h => {
-        columnVisibility.value[tab.id][h] = true;
-        if (table) table.showColumn(fieldMap[h] || h);
-      });
+      tab.headers.slice(1).forEach(h => { columnVisibility.value[tab.id][h] = true; });
+      if (table) table.setColumns(buildTabulatorColumns(tab));
     }
 
     function selectAll(tabId, groupKey) {

--- a/prostars/templates/baseball_stats.html
+++ b/prostars/templates/baseball_stats.html
@@ -152,6 +152,24 @@ window.PROSTARS_CONFIG = {
               <span class="filter-toggle-icon" :class="{ open: filterOpen }">▾</span>
             </button>
             <button class="btn-reset-filter" @click="resetFilters">Reset</button>
+            <button class="filter-toggle-btn" :class="{ active: colPanelOpen }" @click="colPanelOpen = !colPanelOpen" style="margin-left:auto">
+              Columns
+              <span class="filter-toggle-icon" :class="{ open: colPanelOpen }">▾</span>
+            </button>
+          </div>
+
+          <div class="filter-panel" v-show="colPanelOpen">
+            <div class="filter-groups">
+              <div>
+                <div class="filter-group-label">Show / Hide Columns</div>
+                <div class="filter-options" style="flex-direction:row;flex-wrap:wrap;max-height:none">
+                  <label class="filter-option" v-for="h in tab.headers.slice(1)" :key="h">
+                    <input type="checkbox" :checked="columnVisibility[tab.id][h]" @change="toggleColumn(tab.id, h)">
+                    [[ h ]]
+                  </label>
+                </div>
+              </div>
+            </div>
           </div>
 
           <div class="filter-chips" v-if="activeChips.length > 0">

--- a/prostars/templates/hockey_stats.html
+++ b/prostars/templates/hockey_stats.html
@@ -144,6 +144,24 @@ window.PROSTARS_CONFIG = {
               <span class="filter-toggle-icon" :class="{ open: filterOpen }">▾</span>
             </button>
             <button class="btn-reset-filter" @click="resetFilters">Reset</button>
+            <button class="filter-toggle-btn" :class="{ active: colPanelOpen }" @click="colPanelOpen = !colPanelOpen" style="margin-left:auto">
+              Columns
+              <span class="filter-toggle-icon" :class="{ open: colPanelOpen }">▾</span>
+            </button>
+          </div>
+
+          <div class="filter-panel" v-show="colPanelOpen">
+            <div class="filter-groups">
+              <div>
+                <div class="filter-group-label">Show / Hide Columns</div>
+                <div class="filter-options" style="flex-direction:row;flex-wrap:wrap;max-height:none">
+                  <label class="filter-option" v-for="h in tab.headers.slice(1)" :key="h">
+                    <input type="checkbox" :checked="columnVisibility[tab.id][h]" @change="toggleColumn(tab.id, h)">
+                    [[ h ]]
+                  </label>
+                </div>
+              </div>
+            </div>
           </div>
 
           <div class="filter-chips" v-if="activeChips.length > 0">


### PR DESCRIPTION
## Summary

- Columns can be dragged to reorder via Tabulator's built-in `movableColumns`
- New **Columns** button in the filter bar opens a panel with checkboxes to show/hide individual columns
- **Reset** button restores column order and visibility to defaults via `table.setColumns()`

## Test plan

- Drag a column header to reorder — confirm it moves
- Open Columns panel, uncheck a column — confirm it hides
- Click Reset — confirm column order and visibility are restored
- Switch tabs — confirm Columns panel closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)